### PR TITLE
Dropped allowBackup from lib's manifest

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -12,6 +12,4 @@
     <!-- Required to transfer data periodically -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <application android:allowBackup="true" />
-
 </manifest>


### PR DESCRIPTION
This patch prevents app from build error even though the app has `allowBackup="false"` in it's manifest.